### PR TITLE
Panasas

### DIFF
--- a/src/FSAL/fsal_convert.c
+++ b/src/FSAL/fsal_convert.c
@@ -213,8 +213,8 @@ fsal_dev_t posix2fsal_devt(dev_t posix_devid)
 
   fsal_dev_t dev;
 
-  dev.major = posix_devid >> 8;
-  dev.minor = posix_devid & 0xFF;
+  dev.major = major(posix_devid);
+  dev.minor = minor(posix_devid);
 
   return dev;
 }

--- a/src/include/fsal_types.h
+++ b/src/include/fsal_types.h
@@ -281,8 +281,8 @@ typedef struct fsal_fsid__
 
 typedef struct fsal_dev__
 {
-  fsal_uint_t major;
-  fsal_uint_t minor;
+  dev_t major;
+  dev_t minor;
 } fsal_dev_t;
 
 /* The maximum ACLs that a file can support */


### PR DESCRIPTION
The definition of dev_t has changed to cope with modern device
requirements.  Remove hardwired assumptions about dev_t and replace
with macro+lib calls that track.

Signed-off-by: Jim Lieb jlieb@panasas.com
